### PR TITLE
Set ECDH curve to secp384r1 for cloudscraper to bypass WAF

### DIFF
--- a/custom_components/rewe/sensor.py
+++ b/custom_components/rewe/sensor.py
@@ -70,7 +70,7 @@ class ReweSensor(Entity):
         self._name = f"Rewe {self.market_id}"
         self._state = None
         self._available = True
-        self._session = cloudscraper.create_scraper()
+        self._session = cloudscraper.create_scraper(ecdhCurve="secp384r1")
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
# Proposed Changes

To bypass the WAF of the Rewe API endpoint it's necessary (at least in 2024.1.0 with cloudscraper 1.2.71) to set the ECDH curve to secp384r1 in order to allow a reliable communication.

## Related Issues

- https://github.com/foo-git/rewe-discounts/issues/14
- https://github.com/FaserF/ha-rewe/issues/19
